### PR TITLE
Allow empty string to be provided as a group name for unnamed tab groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,19 @@ Before you use this extension, you need to create a set of rules for which
 sites to group into which tabs. Go to the extension options, and there is a
 textbox where you can add the list of rules.
 
-Here's an example of a rule:
+Here are some examples of rules:
 
 ```
-||google.com Google blue
+||google.com Google grey
+||example.atlassian.net "Company JIRA" blue
+||unnamed.example.com ""
 ```
 
-It means group all google web pages (anything at google.com) in a tab group
-called "Google" and color the tab group blue.
+The first example groups all google web pages (anything at google.com) in a tab
+group called "Google" and colors the tab group grey.
+
+The last example creates an unnamed tab group using empty quotes. It will also
+have a default color assigned as none was specified.
 
 Rules consist of a pattern (the `||google.com` part), the name of the tab
 group to group matching tabs under, and an optional color for the tab group to

--- a/options.html
+++ b/options.html
@@ -92,8 +92,11 @@
 ! Group all google sites together
 ||google.com Google green
 
-! Group example.com sites together
-||example.com Example grey
+! Group subdomain.example.net sites together with the default color
+||subdomain.example.net "White space"
+
+! Group example.com sites together in an unnamed group
+||example.com "" green
                 </pre>
             </div>
         </div>

--- a/tabgroups.js
+++ b/tabgroups.js
@@ -97,7 +97,7 @@ function parseRules(rulesText) {
     }
 
     // Make sure we have a valid pattern/name and skip if not
-    if (!pattern || !groupName) {
+    if (!pattern || groupName === undefined) {
       error(`Invalid rule (missing pattern or group name): ${pattern}`);
       return;
     }


### PR DESCRIPTION
As above, this PR allows `""` to be used as a tab group name. e.g.
```
||google.com/ "" green
```
This results in an unnamed tab group as seen in this screenshot:
![image](https://user-images.githubusercontent.com/16645707/122679705-3cc87c80-d22f-11eb-8dce-8e6ca21cceef.png)

I also updated the documentation to make the quoting feature more discoverable 😄

Thanks for making this extension, it's been super useful since I discovered it!