### PR TITLE
Allow groups with the same name but different colors

### DIFF
--- a/tabgroups.js
+++ b/tabgroups.js
@@ -115,6 +115,7 @@ function parseRules(rulesText) {
 function addTabToGroup(tab, groupName, groupColor) {
   chrome.tabGroups.query({
     title: groupName,
+    color: groupColor,
     windowId: tab.windowId,
   }, (groups) => {
     if (groups.length > 0) {


### PR DESCRIPTION
Using rules like:
```
||google.com "" green
||github.com "" yellow
```
Results in only one group being created for both URL patterns.
The change in this pull request remedies this behaviour by including the group color in the tabGroups query.
As a result, unnamed groups can now be used exclusively with every group having a different color :smile: 